### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ def deps do
 end
 ```
 
+And also to your application list. This is important if you are going to make releases of your application, since non-linked applications won't be included in the release and EctoEnum won't be available.
+
+```elixir
+def application do
+  [
+    mod: {HelloPhoenix, []},
+    applications: [
+      # Other dependencies...
+      :ecto_enum
+    ]
+  ]
+end
+```
+
 We will then have to define our enum. We can do this in a separate file since defining
 an enum is just defining a module. We do it like:
 


### PR DESCRIPTION
Update README to show that it's important to add ecto_enum to the application list.

Otherwise, it won't be included in `exrm` releases, causing errors when you are using a model that uses EctoEnum.
