### PR TITLE
values need to be quoted

### DIFF
--- a/lib/ecto_enum/postgres.ex
+++ b/lib/ecto_enum/postgres.ex
@@ -40,7 +40,10 @@ defmodule EctoEnum.Postgres do
         def __valid_values__(), do: @valid_values
 
         def create_type() do
-          types = Enum.join(unquote(list), ", ")
+          types =
+            unquote(list)
+            |> Enum.map(& "'#{&1}'")
+            |> Enum.join(", ")
           sql = "CREATE TYPE #{unquote type} AS ENUM (#{types})"
           Ecto.Migration.execute sql
         end


### PR DESCRIPTION
This addresses a bug with the feature added in #14.

Postgres requires values be single-quoted. Fixes migration error:

```
19:49:22.355 [info]  execute "CREATE TYPE my_type AS ENUM (val1, val2, val3)"
** (Postgrex.Error) ERROR (syntax_error): syntax error at or near "val1"
```
