### PR TITLE
Fix enum-typed MySQL feilds

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -84,6 +84,9 @@ defmodule EctoEnum do
         def load(int) when is_integer(int) do
           Map.fetch(@int_atom_map, int)
         end
+        def load(str) when is_binary(str) do
+          Map.fetch(@string_atom_map, str)
+        end
 
         def dump(term) do
           case EctoEnum.dump(term, @atom_int_kw, @string_int_map, @int_atom_map) do


### PR DESCRIPTION
Mariaex returns strings for fields defined as enum(...)

Unfortunately I still unable to reflect this in tests since I don't know how to create migration with enum field type. Asked in #elixir-lang (IRC, Slack).
