### PR TITLE
Resolve parenthesis ambiguity Elixir 1.4.0-rc.1

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -89,7 +89,7 @@ defmodule EctoEnum do
           case EctoEnum.dump(term, @atom_int_kw, @string_int_map, @int_atom_map) do
             :error ->
               msg = "`#{inspect term}` is not a valid enum value for `#{inspect __MODULE__}`. " <>
-                "Valid enum values are `#{inspect __valid_values__}`"
+                "Valid enum values are `#{inspect __valid_values__()}`"
               raise Ecto.ChangeError,
                 message: msg
             value ->

--- a/mix.exs
+++ b/mix.exs
@@ -7,10 +7,10 @@ defmodule EctoEnum.Mixfile do
     [app: :ecto_enum,
      version: @version,
      elixir: "~> 1.2",
-     deps: deps,
+     deps: deps(),
      description: "Ecto extension to support enums in models",
      test_paths: test_paths(Mix.env),
-     package: package,
+     package: package(),
      name: "EctoEnum",
      docs: [source_ref: "v#{@version}",
             source_url: "https://github.com/gjaldon/ecto_enum"]]


### PR DESCRIPTION
>warning: variable "deps" does not exist and is being expanded to
"deps()", please use parentheses to remove the ambiguity or change the
variable name.

---

Hello there, I noticed these compilation warnings when using Elixir 1.4.0-rc.1, here's a small patch that just adds parenthesis to resolve those ambiguities.