### PR TITLE
Fix crucial typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ def up do
 end
 
 def down do
-  drop_table(:users_pg)
+  drop table(:users_pg)
   StatusEnum.drop_type
 end
 ```


### PR DESCRIPTION
There is no drop_table function in Ecto.Migration, there is drop which take one argument which is table struct, that can be crated by table function that get name of schema. 

So `drop table(:users_pg)` is expanded to `drop(table(:name))` but `drop_table(:users_pg)` simply won't work and will leave potential user with `** (CompileError) long_path_to_a_file.exs:XX: undefined function drop_table/1` where XX is number of offending line in file.

Some might get baffled by the fact that following readme yields error, so the proposed fix for that typo, and might loose some precious time trying to fix it by themselves.

 Sorry for wall of text :(