### PR TITLE
defenum supports keywords variable

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -58,11 +58,11 @@ defmodule EctoEnum do
       [registered: 0, active: 1, inactive: 2, archived: 3]
   """
 
-  defmacro defenum(module, type, enum) when is_list(enum) do
+  defmacro defenum(module, type, enum) do
     EctoEnum.Postgres.defenum(module, type, enum)
   end
 
-  defmacro defenum(module, enum) when is_list(enum) do
+  defmacro defenum(module, enum) do
     quote do
       kw = unquote(enum) |> Macro.escape
 

--- a/test/mysql/ecto_enum_test.exs
+++ b/test/mysql/ecto_enum_test.exs
@@ -3,7 +3,8 @@ defmodule EctoEnumTest do
 
   import Ecto.Changeset
   import EctoEnum
-  defenum StatusEnum, registered: 0, active: 1, inactive: 2, archived: 3
+  keywords = [registered: 0, active: 1, inactive: 2, archived: 3]
+  defenum StatusEnum, keywords
 
   defmodule User do
     use Ecto.Schema

--- a/test/pg/ecto_enum_test.exs
+++ b/test/pg/ecto_enum_test.exs
@@ -2,7 +2,8 @@ defmodule EctoEnumTest do
   use ExUnit.Case
 
   import EctoEnum
-  defenum StatusEnum, registered: 0, active: 1, inactive: 2, archived: 3
+  keywords = [registered: 0, active: 1, inactive: 2, archived: 3]
+  defenum StatusEnum, keywords
 
   defmodule User do
     use Ecto.Schema


### PR DESCRIPTION
Now I have known the keywords like `[registered: 0, active: 1, inactive: 2, archived: 3]` from the third-party library, so I don't have to repeat myself and the definition will be `defenum StatusEnum, keywords`.