### PR TITLE
Update README to use Ecto.Schema instead of Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ in your model's schema block. For example:
 
 ```elixir
 defmodule User do
-  use Ecto.Model
+  use Ecto.Schema
 
   schema "users" do
     field :status, StatusEnum


### PR DESCRIPTION
Ecto.Model is depreciated as of Phoenix v1.1.
http://phoenixframework.org/blog/upgrading-from-v10-to-v11