### PR TITLE
Changes mix.exs to allow installation under a wider range of Ecto v2 versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule EctoEnum.Mixfile do
   end
 
   defp deps do
-    [{:ecto, "~> 2.1.0"},
+    [{:ecto, "~> 2.0"},
      {:postgrex, "~> 0.13.0", optional: true},
      {:mariaex, "~> 0.8.0", optional: true},
      {:ex_doc, "~> 0.11", only: :dev},


### PR DESCRIPTION
Allows installation under >= 2.0.0 < 3.0.0.