### PR TITLE
Make `mix do ecto.rollback, ecto.migrate` safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ defmodule MyApp.Repo.Migrations.AddToGenderEnum do
   @disable_ddl_transaction true
   
   def up do
-    Ecto.Migration.execute "ALTER TYPE gender ADD VALUE 'other'"
+    Ecto.Migration.execute "ALTER TYPE gender ADD VALUE IF NOT EXISTS 'other'"
   end
 
   def down do


### PR DESCRIPTION
When adding a value to an enum type, you can add `IF NOT EXISTS` to prevent migration failure. This should be the default recommendation for adding a type to an enum.