### PR TITLE
Added inclusion validator [Proposition]

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -143,13 +143,14 @@ defmodule EctoEnum do
     def dump(_), do: :error
   end
 
-  def validate_enum(changeset, field) do
+  @spec validate_enum(Ecto.Changeset.t, atom, ((atom, String.t) -> String.t)) :: Ecto.Changeset.t
+  def validate_enum(changeset, field, error_formater \\ fn(field, value) -> "Value #{value} is not member of #{field} enum" end) do
     type = changeset.types[field]
-    value = get_field(changeset,field)
+    value = Ecto.Changeset.get_field(changeset,field)
 
     case type.valid_value?(value) do
       true -> changeset
-      _ -> add_error(changeset, field, "Value #{value} is not member of #{field} enum")
+      _ -> Ecto.Changeset.add_error(changeset, field, error_formater.(field, value))
     end
   end
 end

--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -143,4 +143,13 @@ defmodule EctoEnum do
     def dump(_), do: :error
   end
 
+  def validate_enum(changeset, field) do
+    type = changeset.types[field]
+    value = get_field(changeset,field)
+
+    case type.valid_value?(value) do
+      true -> changeset
+      _ -> add_error(changeset, field, "Value #{value} is not member of #{field} enum")
+    end
+  end
 end

--- a/test/pg/ecto_enum_test.exs
+++ b/test/pg/ecto_enum_test.exs
@@ -83,6 +83,36 @@ defmodule EctoEnumTest do
       "active", "archived", "inactive", "registered"]
   end
 
+  describe "validation inclusion helper" do
+
+    test "returns valid changeset when using valid field value" do
+      changeset = %User{}
+      |> Ecto.Changeset.change(status: :active)
+      |> validate_enum(:status)
+
+      assert changeset.valid?()
+    end
+
+    test "returns defaultlty formated error when status is wrong" do
+      changeset = %User{}
+      |> Ecto.Changeset.change(status: :wrong)
+      |> validate_enum(:status)
+
+      assert %Ecto.Changeset{errors: [status: {"Value wrong is not member of status enum", []}]} = changeset
+      assert !changeset.valid?()
+    end
+
+    test "returns custom formated error when status is wrong" do
+      changeset = %User{}
+      |> Ecto.Changeset.change(status: :wrong)
+      |> validate_enum(:status, fn(field, value) -> "#{field} is not ok, I can't find #{value}" end)
+
+      assert %Ecto.Changeset{errors: [status: {"status is not ok, I can't find wrong", []}]} = changeset
+      assert !changeset.valid?()
+    end
+
+  end
+
   test "defenum/2 can accept variables" do
     x = 0
     defenum TestEnum, zero: x


### PR DESCRIPTION
I've added this to my personal project and I thought others my also find it useful.

It's better than `validate_inclusion` because you only put name of the field and it fetches enum module from the structure definition.