### PR TITLE
Allow to create and use enums in other schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In your migrations, you can make use of helper functions like:
 def up do
   StatusEnum.create_type
   create table(:users_pg) do
-    add :status, :status
+    add :status, StatusEnum.type()
   end
 end
 
@@ -123,8 +123,13 @@ def down do
 end
 ```
 
-`create_type/0` and `drop_type/0` are automatically defined for you in
+`create_type/0`, `type/0` and `drop_type/0` are automatically defined for you in
 your custom Enum module.
+
+You can also create the enum in a different schema:
+```elixir
+defenum StatusEnum, :status, [:registered, :active, :inactive, :archived], schema: "alternative_schema"
+```
 
 ## Important notes/gotchas
 

--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -58,8 +58,8 @@ defmodule EctoEnum do
       [registered: 0, active: 1, inactive: 2, archived: 3]
   """
 
-  defmacro defenum(module, type, enum) do
-    EctoEnum.Postgres.defenum(module, type, enum)
+  defmacro defenum(module, type, enum, options \\ []) do
+    EctoEnum.Postgres.defenum(module, type, enum, options)
   end
 
   defmacro defenum(module, enum) do

--- a/test/pg/ecto_enum_test.exs
+++ b/test/pg/ecto_enum_test.exs
@@ -1,1 +1,49 @@
 Code.require_file "../ecto_enum_test.exs", __DIR__
+
+defmodule EctoEnumPostgresTest do
+  use ExUnit.Case
+
+  import EctoEnum
+
+  alias Ecto.Integration.TestRepo
+
+  test "create_type/1 can accept schema and creates a type in that schema" do
+    Ecto.Adapters.SQL.query!(TestRepo,"CREATE SCHEMA other_schema",[])
+
+    defenum TestEnum, :role, [:admin, :manager, :user], schema: "other_schema"
+
+    defmodule TestMigration do
+      use Ecto.Migration
+
+      def up do
+        TestEnum.create_type()
+
+        create table("users", prefix: "other_schema") do
+          add :role, TestEnum.type()
+        end
+      end
+
+      def down do
+        drop table("users", prefix: "other_schema")
+        TestEnum.drop_type()
+      end
+    end
+
+    assert :ok = Ecto.Migrator.up(TestRepo, 1, TestMigration, log: false)
+
+    defmodule User do
+      use Ecto.Schema
+
+      schema "other_schema.users" do
+        field :role, TestEnum
+      end
+
+      def roles() do
+        [:admin, :manager, :user]
+      end
+    end
+
+
+    Ecto.Migrator.down(TestRepo, 1, TestMigration, log: false)
+  end
+end


### PR DESCRIPTION
fixes #42 

### Some notes
Even though I changed it in the readme, using `StatusEnum.type()` instead of just `:status` in the migrations is not a breaking change.
This was added so we don't have to write `:"other_schema.status"` in case we created the type in another schema. `:status` would still work if you're using the public schema.

Let me know what you think 😃 