### PR TITLE
Update alter type example to include if not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ defmodule MyApp.Repo.Migrations.AddToGenderEnum do
   @disable_ddl_transaction true
 
   def up do
-    Ecto.Migration.execute "ALTER TYPE gender ADD VALUE 'other'"
+    Ecto.Migration.execute "ALTER TYPE gender ADD VALUE IF NOT EXISTS'other'"
   end
 
   def down do


### PR DESCRIPTION
In the example migration to add another value to the type it crashes if you migrate, rollback and then migrate again. Added a `IF NOT EXISTS` which was introduced in postgres 9.3 to prevent that from happening.