### PR TITLE
Make create_type/0 reversible

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,11 @@ above code, this means that you can only pass the following values:
 In your migrations, you can make use of helper functions like:
 
 ```elixir
-def up do
+def change do
   StatusEnum.create_type
   create table(:users_pg) do
     add :status, :status
   end
-end
-
-def down do
-  drop table(:users_pg)
-  StatusEnum.drop_type
 end
 ```
 

--- a/lib/ecto_enum/postgres.ex
+++ b/lib/ecto_enum/postgres.ex
@@ -38,15 +38,23 @@ defmodule EctoEnum.Postgres do
         def __enum_map__(), do: @atom_list
         def __valid_values__(), do: @valid_values
 
-        def create_type() do
-          types = Enum.map_join(unquote(list), ", ", &"'#{&1}'")
-          sql = "CREATE TYPE #{unquote type} AS ENUM (#{types})"
-          Ecto.Migration.execute sql
+        @types Enum.map_join(unquote(list), ", ", &"'#{&1}'")
+        @create_sql "CREATE TYPE #{unquote type} AS ENUM (#{@types})"
+
+        @drop_sql "DROP TYPE #{unquote type}"
+
+        if function_exported?(Ecto.Migration, :execute, 2) do
+          def create_type() do
+            Ecto.Migration.execute @create_sql, @drop_sql
+          end
+        else
+          def create_type() do
+            Ecto.Migration.execute @create_sql
+          end
         end
 
         def drop_type() do
-          sql = "DROP TYPE #{unquote type}"
-          Ecto.Migration.execute sql
+          Ecto.Migration.execute @drop_sql
         end
       end
     end


### PR DESCRIPTION
Ecto 2.2 added `Ecto.Migration.execute/2` which defines a reversible SQL operation. It would be handy if this was used in the definition of `create_type/0` :) 