### PR TITLE
Ensure module loaded before checking exports. Closes #82

### DIFF
--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -60,6 +60,7 @@ defmodule EctoEnum.Postgres.Use do
       create_sql =  "CREATE TYPE #{type} AS ENUM (#{types})"
       drop_sql = "DROP TYPE #{type}"
 
+      Code.ensure_loaded(Ecto.Migration)
       if function_exported?(Ecto.Migration, :execute, 2) do
         def create_type() do
           Ecto.Migration.execute(unquote(create_sql), unquote(drop_sql))


### PR DESCRIPTION
According to https://hexdocs.pm/elixir/Kernel.html#function_exported?/3
> Returns true if module is loaded and contains a public function with the given arity, otherwise false.

In my project, this was always returning false but now has the correct behaviour