### PR TITLE
Add schemaless_type function to postgres enums

### DIFF
--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -59,6 +59,7 @@ defmodule EctoEnum.Postgres.Use do
       type = :"#{schema}.#{input[:type]}"
 
       def type, do: unquote(type)
+      def schemaless_type, do: unquote(input[:type])
 
       def schema, do: unquote(schema)
 


### PR DESCRIPTION
Just a trivial little change to allow callers to get the type name without the schema prefix. This is handy for writing `ALTER TYPE` operations which don't like having the schema included.