### PR TITLE
Auto define enum variants as functions

### DIFF
--- a/lib/ecto_enum/macro.ex
+++ b/lib/ecto_enum/macro.ex
@@ -1,0 +1,12 @@
+defmodule EctoEnum.Macro do
+  def to_function(s) when is_atom(s) do
+    s |> to_string |> to_function()
+  end
+
+  def to_function(s) when is_binary(s) do
+    s
+    |> String.replace(~r/[[:punct:]]/, "_")
+    |> Macro.underscore()
+    |> String.to_atom()
+  end
+end

--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -46,7 +46,7 @@ defmodule EctoEnum.Postgres.Use do
       end
 
       for atom <- enums do
-        def unquote(EctoEnum.Macro.to_function(atom))(), do: unquote(atom)
+        defmacro unquote(EctoEnum.Macro.to_function(atom))(), do: unquote(atom)
       end
 
       def valid_value?(value) do

--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -45,6 +45,10 @@ defmodule EctoEnum.Postgres.Use do
         def load(unquote(string)), do: {:ok, unquote(atom)}
       end
 
+      for atom <- enums do
+        def unquote(atom)(), do: unquote(atom)
+      end
+
       def valid_value?(value) do
         Enum.member?(unquote(valid_values), value)
       end
@@ -68,6 +72,7 @@ defmodule EctoEnum.Postgres.Use do
       drop_sql = "DROP TYPE #{type}"
 
       Code.ensure_loaded(Ecto.Migration)
+
       if function_exported?(Ecto.Migration, :execute, 2) do
         def create_type() do
           Ecto.Migration.execute(unquote(create_sql), unquote(drop_sql))

--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -46,7 +46,7 @@ defmodule EctoEnum.Postgres.Use do
       end
 
       for atom <- enums do
-        def unquote(atom)(), do: unquote(atom)
+        def unquote(EctoEnum.Macro.to_function(atom))(), do: unquote(atom)
       end
 
       def valid_value?(value) do

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -26,6 +26,10 @@ defmodule EctoEnum.Use do
 
       def type, do: unquote(type)
 
+      for {key, value} <- opts do
+        def unquote(key), do: unquote(key)
+      end
+
       for {key, value} <- opts, k <- Enum.uniq([key, value, Atom.to_string(key)]) do
         def cast(unquote(k)), do: {:ok, unquote(key)}
       end

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -27,7 +27,7 @@ defmodule EctoEnum.Use do
       def type, do: unquote(type)
 
       for {key, value} <- opts do
-        def unquote(EctoEnum.Macro.to_function(key))(), do: unquote(value || key)
+        defmacro unquote(EctoEnum.Macro.to_function(key))(), do: unquote(value || key)
       end
 
       for {key, value} <- opts, k <- Enum.uniq([key, value, Atom.to_string(key)]) do

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -27,7 +27,7 @@ defmodule EctoEnum.Use do
       def type, do: unquote(type)
 
       for {key, value} <- opts do
-        def unquote(key), do: unquote(key)
+        def unquote(key)(), do: unquote(value || key)
       end
 
       for {key, value} <- opts, k <- Enum.uniq([key, value, Atom.to_string(key)]) do

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -27,7 +27,7 @@ defmodule EctoEnum.Use do
       def type, do: unquote(type)
 
       for {key, value} <- opts do
-        def unquote(key)(), do: unquote(value || key)
+        def unquote(EctoEnum.Macro.to_function(key))(), do: unquote(value || key)
       end
 
       for {key, value} <- opts, k <- Enum.uniq([key, value, Atom.to_string(key)]) do

--- a/test/ecto_enum_test.exs
+++ b/test/ecto_enum_test.exs
@@ -292,8 +292,30 @@ defmodule EctoEnumTest do
       " Valid enums are `#{inspect(StatusEnum.__valid_values__())}`"
   end
 
-  test "provides getter functions for the keys that match to values of enum" do
+  test "provides getter macros for the keys that match to values of enum" do
+    require StatusEnum
+
     assert StatusEnum.registered() == 0
     assert StringStatusEnum.registered() == "registered"
+  end
+
+  test "getter macros should work in pattern matches" do
+    defmodule Traffic do
+      import EctoEnum
+
+      defenum(LightEnum, ["green", "red", "yellow"])
+
+      require LightEnum
+
+      def action(LightEnum.green()), do: "go!"
+      def action(LightEnum.red()), do: "stop!"
+      def action(LightEnum.yellow()), do: "slow down!"
+    end
+
+    require Traffic.LightEnum
+
+    assert Traffic.action(Traffic.LightEnum.green()) == "go!"
+    assert Traffic.action(Traffic.LightEnum.red()) == "stop!"
+    assert Traffic.action(Traffic.LightEnum.yellow()) == "slow down!"
   end
 end

--- a/test/ecto_enum_test.exs
+++ b/test/ecto_enum_test.exs
@@ -294,28 +294,33 @@ defmodule EctoEnumTest do
 
   test "provides getter macros for the keys that match to values of enum" do
     require StatusEnum
+    require StringStatusEnum
 
     assert StatusEnum.registered() == 0
     assert StringStatusEnum.registered() == "registered"
   end
 
+  defmodule Light do
+    import EctoEnum
+
+    defenum(LightEnum, ["green", "red", "yellow"])
+  end
+
+  defmodule Traffic do
+    alias Light.LightEnum
+    require LightEnum
+
+    def action(LightEnum.green()), do: "go!"
+    def action(LightEnum.red()), do: "stop!"
+    def action(LightEnum.yellow()), do: "slow down!"
+  end
+
   test "getter macros should work in pattern matches" do
-    defmodule Traffic do
-      import EctoEnum
+    alias Light.LightEnum
+    require LightEnum
 
-      defenum(LightEnum, ["green", "red", "yellow"])
-
-      require LightEnum
-
-      def action(LightEnum.green()), do: "go!"
-      def action(LightEnum.red()), do: "stop!"
-      def action(LightEnum.yellow()), do: "slow down!"
-    end
-
-    require Traffic.LightEnum
-
-    assert Traffic.action(Traffic.LightEnum.green()) == "go!"
-    assert Traffic.action(Traffic.LightEnum.red()) == "stop!"
-    assert Traffic.action(Traffic.LightEnum.yellow()) == "slow down!"
+    assert Traffic.action(LightEnum.green()) == "go!"
+    assert Traffic.action(LightEnum.red()) == "stop!"
+    assert Traffic.action(LightEnum.yellow()) == "slow down!"
   end
 end

--- a/test/ecto_enum_test.exs
+++ b/test/ecto_enum_test.exs
@@ -291,4 +291,9 @@ defmodule EctoEnumTest do
     "Value `#{inspect(value)}` is not a valid enum for `EctoEnumTest.StatusEnum`." <>
       " Valid enums are `#{inspect(StatusEnum.__valid_values__())}`"
   end
+
+  test "provides getter functions for the keys that match to values of enum" do
+    assert StatusEnum.registered() == 0
+    assert StringStatusEnum.registered() == "registered"
+  end
 end

--- a/test/pg/postgres_test.exs
+++ b/test/pg/postgres_test.exs
@@ -2,7 +2,7 @@ defmodule EctoEnum.PostgresTest do
   use ExUnit.Case, async: false
 
   import EctoEnum
-  defenum StatusEnum, :status, [:registered, :active, :inactive, :archived]
+  defenum StatusEnum, :status, [:registered, :active, :inactive, :archived, :"on-hold"]
 
   defmodule User do
     use Ecto.Schema
@@ -82,5 +82,6 @@ defmodule EctoEnum.PostgresTest do
 
   test "provides getter functions for the keys that match to values of enum" do
     assert StatusEnum.registered() == :registered
+    assert StatusEnum.on_hold() == :"on-hold"
   end
 end

--- a/test/pg/postgres_test.exs
+++ b/test/pg/postgres_test.exs
@@ -79,4 +79,8 @@ defmodule EctoEnum.PostgresTest do
 
     assert NewType.cast("ready") == {:ok, :ready}
   end
+
+  test "provides getter functions for the keys that match to values of enum" do
+    assert StatusEnum.registered() == :registered
+  end
 end

--- a/test/pg/postgres_test.exs
+++ b/test/pg/postgres_test.exs
@@ -80,8 +80,28 @@ defmodule EctoEnum.PostgresTest do
     assert NewType.cast("ready") == {:ok, :ready}
   end
 
-  test "provides getter functions for the keys that match to values of enum" do
+  test "provides getter macros for the keys that match to values of enum" do
+    require StatusEnum
+
     assert StatusEnum.registered() == :registered
     assert StatusEnum.on_hold() == :"on-hold"
+  end
+
+  test "getter macros should work in pattern matches" do
+    defmodule Traffic do
+      import EctoEnum
+
+      defenum(LightEnum, :traffic_light_enum, [:green, :red, :yellow])
+
+      def action(LightEnum.green()), do: "go!"
+      def action(LightEnum.red()), do: "stop!"
+      def action(LightEnum.yellow()), do: "slow down!"
+    end
+
+    require Traffic.LightEnum
+
+    assert Traffic.action(Traffic.LightEnum.green()) == "go!"
+    assert Traffic.action(Traffic.LightEnum.red()) == "stop!"
+    assert Traffic.action(Traffic.LightEnum.yellow()) == "slow down!"
   end
 end

--- a/test/pg/postgres_test.exs
+++ b/test/pg/postgres_test.exs
@@ -87,21 +87,24 @@ defmodule EctoEnum.PostgresTest do
     assert StatusEnum.on_hold() == :"on-hold"
   end
 
+  defmodule Light do
+    import EctoEnum
+
+    defenum(LightEnum, :traffic_light_enum, [:green, :red, :yellow])
+  end
+
+  defmodule Traffic do
+    require Light.LightEnum
+    def action(Light.LightEnum.green()), do: "go!"
+    def action(Light.LightEnum.red()), do: "stop!"
+    def action(Light.LightEnum.yellow()), do: "slow down!"
+  end
+
   test "getter macros should work in pattern matches" do
-    defmodule Traffic do
-      import EctoEnum
+    require Light.LightEnum
 
-      defenum(LightEnum, :traffic_light_enum, [:green, :red, :yellow])
-
-      def action(LightEnum.green()), do: "go!"
-      def action(LightEnum.red()), do: "stop!"
-      def action(LightEnum.yellow()), do: "slow down!"
-    end
-
-    require Traffic.LightEnum
-
-    assert Traffic.action(Traffic.LightEnum.green()) == "go!"
-    assert Traffic.action(Traffic.LightEnum.red()) == "stop!"
-    assert Traffic.action(Traffic.LightEnum.yellow()) == "slow down!"
+    assert Traffic.action(Light.LightEnum.green()) == "go!"
+    assert Traffic.action(Light.LightEnum.red()) == "stop!"
+    assert Traffic.action(Light.LightEnum.yellow()) == "slow down!"
   end
 end


### PR DESCRIPTION
Implements https://github.com/gjaldon/ecto_enum/issues/87

This patch allows using enum variants as you would use a constant in some languages or a full featured Enum in others.

When variants are defined on an enum, a matching function will be defined for reducing code re-definitions.

It allows for usage as:

```
defenum StatusEnum, ["registered", "active", "inactive", "archived"]

> StatusEnum.registered()
=> "registered"
```

Complex atom types are also coerced into idiomatic names:

```
defenum StatusEnum, [:"on-hold"]

> StatusEnum.on_hold()
=> :"on-hold"
```

This PR works for both arity 2 and 3 versions of `defenum`. I had tested it for different cases in PG but have not deeply assessed any changes needed for MySQL.

You're welcome to tweak the PR for small changes and I'm happy to adjust it myself if something more thorough is needed.

:D 