### PR TITLE
update with new required callbacks

### DIFF
--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -38,6 +38,10 @@ defmodule EctoEnum.Postgres.Use do
         raise Ecto.ChangeError, message: msg
       end
 
+      def embed_as(_), do: :self
+
+      def equal?(term1, term2), do: term1 == term2
+
       for atom <- enums do
         string = Atom.to_string(atom)
 
@@ -68,6 +72,7 @@ defmodule EctoEnum.Postgres.Use do
       drop_sql = "DROP TYPE #{type}"
 
       Code.ensure_loaded(Ecto.Migration)
+
       if function_exported?(Ecto.Migration, :execute, 2) do
         def create_type() do
           Ecto.Migration.execute(unquote(create_sql), unquote(drop_sql))

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -44,6 +44,10 @@ defmodule EctoEnum.Use do
         raise Ecto.ChangeError, message: msg
       end
 
+      def embed_as(_), do: :self
+
+      def equal?(term1, term2), do: term1 == term2
+
       for {key, value} <- opts do
         def load(unquote(value)), do: {:ok, unquote(key)}
       end


### PR DESCRIPTION
Ecto 3.2.0 came out a couple days ago, and it adds some new required callbacks to `Ecto.Type`. This PR adds those new callbacks and uses the same defaults as Ecto chose to.

Ecto changelog here: https://github.com/elixir-ecto/ecto/blob/master/CHANGELOG.md#enhancements
Ecto defaults here: https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/type.ex#L86-L87

This fixes #91 