### PR TITLE
Support loading of mysql enum fields that are returned as strings

### DIFF
--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -50,6 +50,7 @@ defmodule EctoEnum.Use do
 
       for {key, value} <- opts do
         def load(unquote(value)), do: {:ok, unquote(key)}
+        def load(unquote(Atom.to_string(key))), do: {:ok, unquote(key)}
       end
 
       def valid_value?(value) do


### PR DESCRIPTION
Hi!
Is it possible to support loading of fields declared as ENUM (mysql ?).
Created a test project to reveal this issue: https://github.com/alesasnouski/ecto_enum_t  - see README.md and migration for details.
Thanks!