### PR TITLE
allow empty enums

### DIFF
--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -9,7 +9,9 @@ defmodule EctoEnum.Postgres.Use do
 
       @behaviour Ecto.Type
 
-      @type t :: unquote(typespec)
+      if typespec do
+        @type t :: unquote(typespec)
+      end
 
       enums = input[:enums]
       valid_values = enums ++ Enum.map(enums, &Atom.to_string/1)
@@ -48,6 +50,8 @@ defmodule EctoEnum.Postgres.Use do
         def load(unquote(atom)), do: {:ok, unquote(atom)}
         def load(unquote(string)), do: {:ok, unquote(atom)}
       end
+
+      def load(_), do: :error
 
       def valid_value?(value) do
         Enum.member?(unquote(valid_values), value)

--- a/lib/ecto_enum/typespec.ex
+++ b/lib/ecto_enum/typespec.ex
@@ -1,6 +1,9 @@
 defmodule EctoEnum.Typespec do
   @moduledoc "Helper for generating enum typespecs"
 
+  def make([]), do: nil
+  def make(%{} = x) when map_size(x) == 0, do: nil
+
   def make(enums) do
     enums
     |> Enum.reverse()

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -9,7 +9,9 @@ defmodule EctoEnum.Use do
 
       @behaviour Ecto.Type
 
-      @type t :: unquote(typespec)
+      if typespec do
+        @type t :: unquote(typespec)
+      end
 
       keys = Keyword.keys(opts)
       string_keys = Enum.map(keys, &Atom.to_string/1)
@@ -51,6 +53,8 @@ defmodule EctoEnum.Use do
       for {key, value} <- opts do
         def load(unquote(value)), do: {:ok, unquote(key)}
       end
+
+      def load(_), do: :error
 
       def valid_value?(value) do
         Enum.member?(@valid_values, value)

--- a/test/ecto_enum_test.exs
+++ b/test/ecto_enum_test.exs
@@ -287,6 +287,18 @@ defmodule EctoEnumTest do
               ]}
   end
 
+  test "allow empty enums" do
+    require EctoEnum
+
+    EctoEnum.defenum(
+      Void,
+      :void,
+      []
+    )
+
+    assert Void.__enums__() == []
+  end
+
   def custom_error_msg(value) do
     "Value `#{inspect(value)}` is not a valid enum for `EctoEnumTest.StatusEnum`." <>
       " Valid enums are `#{inspect(StatusEnum.__valid_values__())}`"


### PR DESCRIPTION
In some cases in development process we should deal with empty enums. For example if actual business logic is not implemented yet, but we know for sure that there will be enum (which is empty atm). Or otherwise - we remove some values and enum become empty. To make development process smoother I want to support empty enums - in this case if business logic changes somehow, we don't need to modify enum-related code at all.