### PR TITLE
Expose atom values as 0-arity macros

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -84,6 +84,16 @@ defmodule EctoEnum do
 
       iex> t(StatusEnum)
       @type t() :: :registered | :active | :inactive | :archived
+
+  Finally, Enums expose their values as 0-arity macros. This provides
+  call-site validation that the value being passed in is indeed a member
+  of the enum, while providing identical runtime behaviour to simply
+  using the atom directly.
+
+      iex> require StatusEnum
+      StatusEnum
+      iex> StatusEnum.registered
+      :registered
   """
 
   defmacro __using__(opts) do

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -56,6 +56,10 @@ defmodule EctoEnum.Use do
         Enum.member?(@valid_values, value)
       end
 
+      for atom <- keys do
+        defmacro unquote(atom)(), do: unquote(atom)
+      end
+
       # # Reflection
       def __enum_map__(), do: unquote(opts)
       def __valid_values__(), do: @valid_values

--- a/test/ecto_enum_test.exs
+++ b/test/ecto_enum_test.exs
@@ -292,3 +292,23 @@ defmodule EctoEnumTest do
       " Valid enums are `#{inspect(StatusEnum.__valid_values__())}`"
   end
 end
+
+defmodule ExternalEnum do
+  use EctoEnum, ready: 0, set: 1, go: 2
+end
+
+defmodule MacrosTest do
+  use ExUnit.Case
+
+  test "it inserts the enum value" do
+    require ExternalEnum
+    assert :ready == ExternalEnum.ready
+  end
+
+  test "it will validate non-existent values" do
+    require ExternalEnum
+    assert_raise(UndefinedFunctionError, fn ->
+      ExternalEnum.not_a_value
+    end)
+  end
+end


### PR DESCRIPTION
The runtime behaviour of a called macro is identical to simply using
the raw atom. However, invoking it as a macro provides compile-time
validation that the value exists on the Enum.