### PR TITLE
test: compile test module only on test

### DIFF
--- a/lib/ecto_enum/typespec.ex
+++ b/lib/ecto_enum/typespec.ex
@@ -13,17 +13,3 @@ defmodule EctoEnum.Typespec do
 
   defp add_type(type, acc), do: {:|, [], [type, acc]}
 end
-
-defmodule EctoEnum.Typespec.TestModule do
-  @moduledoc """
-  Sample enum-containing module for testing type generation. Types aren't
-  generated for dynamically generated modules that eunit uses, so we have to
-  prepare this module in advance
-  """
-
-  import EctoEnum
-
-  defenum StatusEnum, registered: 0, active: 1, inactive: 2, archived: 3
-
-  defenum PGStatusEnum, :status, [:registered, :active, :inactive, :archived]
-end

--- a/mix.exs
+++ b/mix.exs
@@ -13,12 +13,16 @@ defmodule EctoEnum.Mixfile do
       test_paths: test_paths(Mix.env()),
       package: package(),
       name: "EctoEnum",
-      docs: [source_ref: "v#{@version}", source_url: "https://github.com/gjaldon/ecto_enum"]
+      docs: [source_ref: "v#{@version}", source_url: "https://github.com/gjaldon/ecto_enum"],
+      elixirc_paths: elixrc_paths(Mix.env())
     ]
   end
 
   defp test_paths(:mysql), do: ["test/mysql"]
   defp test_paths(_), do: ["test/pg"]
+
+  defp elixrc_paths(env) when env in ~w(mysql test)a, do: ["lib", "test/support"]
+  defp elixrc_paths(_), do: ["lib"]
 
   defp package do
     [

--- a/test/support/typespec_test_module.ex
+++ b/test/support/typespec_test_module.ex
@@ -1,0 +1,13 @@
+defmodule EctoEnum.Typespec.TestModule do
+  @moduledoc """
+  Sample enum-containing module for testing type generation. Types aren't
+  generated for dynamically generated modules that eunit uses, so we have to
+  prepare this module in advance
+  """
+
+  import EctoEnum
+
+  defenum StatusEnum, registered: 0, active: 1, inactive: 2, archived: 3
+
+  defenum PGStatusEnum, :status, [:registered, :active, :inactive, :archived]
+end


### PR DESCRIPTION
Sorry for not even opening an issue, I realized that just opening a PR and explaining would be easier and better for the contribution.

So, when looking at the source code I realize this repository was compiling a module intended only to test it's typespec generation. The problem with that is that then this is shipped to all codebases that use this library.

Another problem is that this adds those modules to the generated ex_docs, which can make people wonder whether or not they are supposed to understand their purpose.

This PR solves this problem by moving that file to a `test/support` directory and by setting the `elixirc_paths` to include `test/support` only on test environments (`test` and `mysql`).