### PR TITLE
Fix usage for list of strings and add some bang functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To `use` `EctoEnum` with string-backed storage:
 
 ```elixir
 defmodule CustomEnum do
-  use EctoEnum, "ready", "set", "go"
+  use EctoEnum, ["ready", "set", "go"]
 end
 ```
 

--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -105,19 +105,6 @@ defmodule EctoEnum do
   defmacro defenum(module, enum) do
     quote do
       enum = Macro.escape(unquote(enum))
-      [h | _t] = enum
-
-      enum =
-        cond do
-          Keyword.keyword?(enum) ->
-            enum
-
-          is_binary(h) ->
-            Enum.map(enum, fn value -> {String.to_atom(value), value} end)
-
-          true ->
-            raise "Enum must be a keyword list or a list of strings"
-        end
 
       defmodule unquote(module) do
         use EctoEnum.Use, enum

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -64,6 +64,18 @@ defmodule EctoEnum.Use do
         raise Ecto.ChangeError, message: msg
       end
 
+      for {key, value} <- opts, k <- Enum.uniq([key, value, Atom.to_string(key)]) do
+        def dump!(unquote(k)), do: unquote(value)
+      end
+
+      def dump!(term) do
+        msg =
+          "Value `#{inspect(term)}` is not a valid enum for `#{inspect(__MODULE__)}`. " <>
+            "Valid enums are `#{inspect(__valid_values__())}`"
+
+        raise Ecto.ChangeError, message: msg
+      end
+
       def embed_as(_), do: :self
 
       def equal?(term1, term2), do: term1 == term2


### PR DESCRIPTION
The following example in README.md was incorrect:

```
use EctoEnum, "one", "two", "three"
```

But even the correct one was not working:

```
use EctoEnum, ["one", "two", "three"]
```

I moved the check from `defenum` to be in use for `EctoEnum.Use` module and now it's working correctly.

In the same way I missed a couple of functions I usually use like `cast!/1` and `dump!/1`. Both were added as well.