### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ defenum StatusEnum, registered: 0, active: 1, inactive: 2, archived: 3
 Note that we can also use string-backed enums by doing the following:
 
 ```elixir
-defenum StatusEnum, registered: "registered", active: "active", inactive: "active", archived: "archived"
+defenum StatusEnum, registered: "registered", active: "active", inactive: "inactive", archived: "archived"
 # short-cut way of using string-backed enums
 defenum StatusEnum, ["registered", "active", "inactive", "archived"]
 ```


### PR DESCRIPTION
Need "inactive" key and value to match.