### PR TITLE
add type option to reflection function

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -74,11 +74,23 @@ defmodule EctoEnum do
       Valid enum values are `[0, 1, 2, 3, :registered, :active, :inactive, :archived, "active",
       "archived", "inactive", "registered"]`
 
-  The enum type `StatusEnum` will also have a reflection function for inspecting the
+  The enum type `StatusEnum` will also have reflection functions for inspecting the
   enum map in runtime.
 
       iex> StatusEnum.__enum_map__()
       [registered: 0, active: 1, inactive: 2, archived: 3]
+
+      iex> StatusEnum.__valid_values__()
+      [:registered, :active, :inactive, :archived, "registered", "active", "inactive", "archived", 0, 1, 2, 3]
+
+      iex> StatusEnum.__valid_values__(:atom)
+      [:registered, :active, :inactive, :archived]
+
+      iex> StatusEnum.__valid_values__(:string)
+      ["registered", "active", "inactive", "archived"]
+
+      iex> StatusEnum.__valid_values__(:integer)
+      [0, 1, 2, 3]
 
   Enums also generate a typespec for use with dialyzer, available as the `t()` type
 

--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -12,7 +12,8 @@ defmodule EctoEnum.Postgres.Use do
       @type t :: unquote(typespec)
 
       enums = input[:enums]
-      valid_values = enums ++ Enum.map(enums, &Atom.to_string/1)
+      string_values = Enum.map(enums, &Atom.to_string/1)
+      valid_values = enums ++ string_values
 
       for atom <- enums do
         string = Atom.to_string(atom)
@@ -57,6 +58,9 @@ defmodule EctoEnum.Postgres.Use do
       def __enums__(), do: unquote(enums)
       def __enum_map__(), do: __enums__()
       def __valid_values__(), do: unquote(valid_values)
+      def __valid_values__(:atom), do: unquote(enums)
+      def __valid_values__(:string), do: unquote(string_values)
+      def __valid_values__(:integer), do: []
 
       default_schema = "public"
       schema = Keyword.get(input, :schema, default_schema)

--- a/lib/ecto_enum/use.ex
+++ b/lib/ecto_enum/use.ex
@@ -14,6 +14,9 @@ defmodule EctoEnum.Use do
       keys = Keyword.keys(opts)
       string_keys = Enum.map(keys, &Atom.to_string/1)
       @valid_values Enum.uniq(keys ++ string_keys ++ Keyword.values(opts))
+      @valid_string_values Enum.filter(@valid_values, &is_binary/1)
+      @valid_atom_values Enum.filter(@valid_values, &is_atom/1)
+      @valid_integer_values Enum.filter(@valid_values, &is_integer/1)
 
       {_key, value} = opts |> hd()
 
@@ -59,6 +62,9 @@ defmodule EctoEnum.Use do
       # # Reflection
       def __enum_map__(), do: unquote(opts)
       def __valid_values__(), do: @valid_values
+      def __valid_values__(:atom), do: @valid_atom_values
+      def __valid_values__(:string), do: @valid_string_values
+      def __valid_values__(:integer), do: @valid_integer_values
     end
   end
 end

--- a/test/ecto_enum_test.exs
+++ b/test/ecto_enum_test.exs
@@ -105,6 +105,17 @@ defmodule EctoEnumTest do
     end
   end
 
+  test "reflection limited to types" do
+    expected_values = ["active", "archived", "inactive", "registered"]
+    assert Enum.sort(StatusEnum.__valid_values__(:string)) == expected_values
+
+    expected_values = [:active, :archived, :inactive, :registered]
+    assert Enum.sort(StatusEnum.__valid_values__(:atom)) == expected_values
+
+    expected_values = [0, 1, 2, 3]
+    assert Enum.sort(StatusEnum.__valid_values__(:integer)) == expected_values
+  end
+
   describe "validate_enum/3" do
     test "returns a valid changeset when using a valid field value" do
       changeset =


### PR DESCRIPTION
This adds an option to only return valid values for a certain type, which I needed in multiple projects now for both generating test data and generating Absinthe/GraphQL enums from Ecto enums.

```
iex> StatusEnum.__valid_values__()
[:registered, :active, :inactive, :archived, "registered", "active", "inactive", "archived", 0, 1, 2, 3]
iex> StatusEnum.__valid_values__(:atom)
[:registered, :active, :inactive, :archived]
iex> StatusEnum.__valid_values__(:string)
["registered", "active", "inactive", "archived"]
iex> StatusEnum.__valid_values__(:integer)
[0, 1, 2, 3]
```

To keep it consistent, I added all of the options to `EctoEnum.Postgres.Use`, although `:integer` will always return an empty list there.