### PR TITLE
Resolve compile error with otp 25

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -105,14 +105,13 @@ defmodule EctoEnum do
   defmacro defenum(module, enum) do
     quote do
       enum = Macro.escape(unquote(enum))
-      [h | _t] = enum
 
       enum =
         cond do
           Keyword.keyword?(enum) ->
             enum
 
-          is_binary(h) ->
+          is_binary(List.first(enum)) ->
             Enum.map(enum, fn value -> {String.to_atom(value), value} end)
 
           true ->


### PR DESCRIPTION
Blast from the past @gjaldon 

![image](https://user-images.githubusercontent.com/38899847/204390741-43041248-0aed-4d19-afa0-de194ac833d2.png)

Getting compile time errors when compiling with Elixir 1.14.2 / OTP 25.1.2. The code I am changing is not incorrect but for some reason the compiler does not like it.