### PR TITLE
fix warning the underscored variable

### DIFF
--- a/lib/ecto_enum.ex
+++ b/lib/ecto_enum.ex
@@ -105,14 +105,13 @@ defmodule EctoEnum do
   defmacro defenum(module, enum) do
     quote do
       enum = Macro.escape(unquote(enum))
-      [h | _t] = enum
 
       enum =
         cond do
           Keyword.keyword?(enum) ->
             enum
 
-          is_binary(h) ->
+          enum |> List.first() |> is_binary() ->
             Enum.map(enum, fn value -> {String.to_atom(value), value} end)
 
           true ->


### PR DESCRIPTION
fixes: 

```
warning: the underscored variable "_t" is used after being set. A leading underscore indicates that the value of the variable should be ignored. If this is intended please rename the variable to remove the underscore
```