### PR TITLE
Set schema in type only when specified

### DIFF
--- a/lib/ecto_enum/postgres/use.ex
+++ b/lib/ecto_enum/postgres/use.ex
@@ -58,9 +58,11 @@ defmodule EctoEnum.Postgres.Use do
       def __enum_map__(), do: __enums__()
       def __valid_values__(), do: unquote(valid_values)
 
-      default_schema = "public"
-      schema = Keyword.get(input, :schema, default_schema)
-      type = :"#{schema}.#{input[:type]}"
+      {schema, type} =
+        case Keyword.fetch(input, :schema) do
+          {:ok, schema} -> {schema, :"#{schema}.#{input[:type]}"}
+          :error -> {nil, :"#{input[:type]}"}
+        end
 
       def type, do: unquote(type)
       def schemaless_type, do: unquote(input[:type])


### PR DESCRIPTION
When adjusting the `search_path` of a connection / user, I would expect `ecto_enum` to respect the given search path.

This PR modifies the behavior so that the schema is only explicitly set when the user specifies the option.